### PR TITLE
[url_launcher] suppress a `uses or overrides a deprecated API` warning in WebViewActivity

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.3
+
+* Suppress deprecation warning on the `shouldOverrideUrlLoading` method on Android of the `FlutterWebChromeClient` class.
+
 ## 5.7.2
 
 * Add API documentation explaining the [canLaunch] method returns `false` if package visibility (Android API 30) is not managed correctly.

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -86,8 +86,12 @@ public class WebViewActivity extends Activity {
               return true;
             }
 
-            @Override
+            /*
+            * This method is deprecated in API 24. Still overridden to support
+            * earlier Android versions.
+            */
             @SuppressWarnings("deprecation")
+            @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
               webview.loadUrl(url);
               return true;

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -87,6 +87,7 @@ public class WebViewActivity extends Activity {
             }
 
             @Override
+            @SuppressWarnings("deprecation")
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
               webview.loadUrl(url);
               return true;

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.7.2
+version: 5.7.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The url_launcher overrides the deprecated `shouldOverrideUrlLoading(WebView view, String url)` method to be backwards compatible with versions before Android API 24. This however currently displays the warning `WebViewActivity.java uses or overrides a deprecated API.` when building for Android. This is causing some problems for developers who treat these warnings as errors as part of their build configuration.

This PR addresses this issue by annotating the `shouldOverrideUrlLoading(WebView view, String url)` method with the @SuppressWarnings("deprecation") attribute.

## Related Issues

[Issue 60986](https://github.com/flutter/flutter/issues/60986)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
