### PR TITLE
Updated platform interface to have recording methods return XFile instances

### DIFF
--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -80,7 +80,7 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Starts a video recording and returns the file where it will be saved.
   ///
   /// The file is written on the flight as the video is being recorded.
-  /// The file can be read as soon as [stopVideoRecording] returns it.
+  /// The file can be read as soon as [stopVideoRecording] returns.
   Future<XFile> startVideoRecording(int cameraId) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 
+import 'package:camera_platform_interface/src/method_channel/method_channel_camera.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/widgets.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:camera_platform_interface/src/method_channel/method_channel_camera.dart';
 
 import '../../camera_platform_interface.dart';
 
@@ -68,8 +68,9 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Captures an image and returns the file where it was saved.
-  /// If no [file] parameter is provided, the file returned will be in a temporary location.
-  Future<XFile> takePicture(int cameraId, { XFile file }) {
+  /// If no [file] parameter is provided, the file returned will be in a
+  /// temporary location.
+  Future<XFile> takePicture(int cameraId, {XFile file}) {
     throw UnimplementedError('takePicture() is not implemented.');
   }
 
@@ -78,14 +79,16 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('prepareForVideoRecording() is not implemented.');
   }
 
-  /// Starts a video recording
+  /// Starts a video recording.
   ///
-  /// If no [file] parameter is provided, the recording will be saved to a new file in a temporary location.
+  /// If no [file] parameter is provided, the recording will be saved to a new
+  /// file in a temporary location.
   ///
   /// The file is written on the flight as the video is being recorded.
-  /// If a file already exists at the path for the provided file instance, an error will be thrown.
+  /// If a file already exists at the path for the provided file instance,
+  /// an error will be thrown.
   /// The file can be read as soon as [stopVideoRecording] returns it.
-  Future<XFile> startVideoRecording(int cameraId, { XFile file }) {
+  Future<XFile> startVideoRecording(int cameraId, {XFile file}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/widgets.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:camera_platform_interface/src/method_channel/method_channel_camera.dart';
@@ -67,7 +68,7 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Captures an image and saves it to [path].
-  Future<void> takePicture(int cameraId, String path) {
+  Future<XFile> takePicture(int cameraId) {
     throw UnimplementedError('takePicture() is not implemented.');
   }
 
@@ -84,12 +85,12 @@ abstract class CameraPlatform extends PlatformInterface {
   /// The file is written on the flight as the video is being recorded.
   /// If a file already exists at the provided path an error will be thrown.
   /// The file can be read as soon as [stopVideoRecording] returns.
-  Future<void> startVideoRecording(int cameraId, String path) {
+  Future<void> startVideoRecording(int cameraId) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 
   /// Stop the video recording.
-  Future<void> stopVideoRecording(int cameraId) {
+  Future<XFile> stopVideoRecording(int cameraId) {
     throw UnimplementedError('stopVideoRecording() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -68,9 +68,7 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Captures an image and returns the file where it was saved.
-  /// If no [file] parameter is provided, the file returned will be in a
-  /// temporary location.
-  Future<XFile> takePicture(int cameraId, {XFile file}) {
+  Future<XFile> takePicture(int cameraId) {
     throw UnimplementedError('takePicture() is not implemented.');
   }
 
@@ -79,21 +77,16 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('prepareForVideoRecording() is not implemented.');
   }
 
-  /// Starts a video recording.
-  ///
-  /// If no [file] parameter is provided, the recording will be saved to a new
-  /// file in a temporary location.
+  /// Starts a video recording and returns the file where it will be saved.
   ///
   /// The file is written on the flight as the video is being recorded.
-  /// If a file already exists at the path for the provided file instance,
-  /// an error will be thrown.
   /// The file can be read as soon as [stopVideoRecording] returns it.
-  Future<XFile> startVideoRecording(int cameraId, {XFile file}) {
+  Future<XFile> startVideoRecording(int cameraId) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 
-  /// Stops the video recording and returns the file where it was saved.
-  Future<XFile> stopVideoRecording(int cameraId) {
+  /// Stops the video recording.
+  Future<void> stopVideoRecording(int cameraId) {
     throw UnimplementedError('stopVideoRecording() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -67,8 +67,9 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('onCameraError() is not implemented.');
   }
 
-  /// Captures an image and returns the file where it was saved
-  Future<XFile> takePicture(int cameraId) {
+  /// Captures an image and returns the file where it was saved.
+  /// If no [file] parameter is provided, the file returned will be in a temporary location.
+  Future<XFile> takePicture(int cameraId, { XFile file }) {
     throw UnimplementedError('takePicture() is not implemented.');
   }
 
@@ -79,10 +80,12 @@ abstract class CameraPlatform extends PlatformInterface {
 
   /// Starts a video recording
   ///
+  /// If no [file] parameter is provided, the recording will be saved to a new file in a temporary location.
+  /// 
   /// The file is written on the flight as the video is being recorded.
-  /// If a file already exists at the provided path an error will be thrown.
+  /// If a file already exists at the path for the provided file instance, an error will be thrown.
   /// The file can be read as soon as [stopVideoRecording] returns it.
-  Future<void> startVideoRecording(int cameraId) {
+  Future<XFile> startVideoRecording(int cameraId, { XFile file }) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -67,7 +67,7 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('onCameraError() is not implemented.');
   }
 
-  /// Captures an image and saves it to [path].
+  /// Captures an image and returns the file where it was saved
   Future<XFile> takePicture(int cameraId) {
     throw UnimplementedError('takePicture() is not implemented.');
   }
@@ -77,19 +77,16 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('prepareForVideoRecording() is not implemented.');
   }
 
-  /// Start a video recording and save the file to [path].
-  ///
-  /// A path can for example be obtained using
-  /// [path_provider](https://pub.dartlang.org/packages/path_provider).
+  /// Starts a video recording
   ///
   /// The file is written on the flight as the video is being recorded.
   /// If a file already exists at the provided path an error will be thrown.
-  /// The file can be read as soon as [stopVideoRecording] returns.
+  /// The file can be read as soon as [stopVideoRecording] returns it.
   Future<void> startVideoRecording(int cameraId) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 
-  /// Stop the video recording.
+  /// Stops the video recording and returns the file where it was saved
   Future<XFile> stopVideoRecording(int cameraId) {
     throw UnimplementedError('stopVideoRecording() is not implemented.');
   }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -81,7 +81,7 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Starts a video recording
   ///
   /// If no [file] parameter is provided, the recording will be saved to a new file in a temporary location.
-  /// 
+  ///
   /// The file is written on the flight as the video is being recorded.
   /// If a file already exists at the path for the provided file instance, an error will be thrown.
   /// The file can be read as soon as [stopVideoRecording] returns it.
@@ -89,7 +89,7 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 
-  /// Stops the video recording and returns the file where it was saved
+  /// Stops the video recording and returns the file where it was saved.
   Future<XFile> stopVideoRecording(int cameraId) {
     throw UnimplementedError('stopVideoRecording() is not implemented.');
   }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -86,6 +86,10 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Stops the video recording.
+  ///
+  /// When the [stopVideoRecording] method completes successfully the recorded
+  /// video can be accessed through the file returned by the 
+  /// [startVideoRecording] method.
   Future<void> stopVideoRecording(int cameraId) {
     throw UnimplementedError('stopVideoRecording() is not implemented.');
   }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   meta: ^1.0.5
   plugin_platform_interface: ^1.0.1
+  file_selector_platform_interface: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -156,7 +156,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.startVideoRecording(1, null),
+        () => cameraPlatform.startVideoRecording(1),
         throwsUnimplementedError,
       );
     });
@@ -182,7 +182,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.takePicture(1, null),
+        () => cameraPlatform.takePicture(1),
         throwsUnimplementedError,
       );
     });


### PR DESCRIPTION
- Currently imports XFile class from added `file_selector_platform_interface` dependency. To be changed later when [`cross_file` PR](https://github.com/flutter/plugins/pull/3260) is merged.