### PR TITLE
[image_picker] Selecting one image in getMultiImage() method

### DIFF
--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -537,8 +537,13 @@ public class ImagePickerDelegate
   private void handleChooseMultiImageResult(int resultCode, Intent data) {
     if (resultCode == Activity.RESULT_OK && data != null) {
       ArrayList<String> paths = new ArrayList<>();
-      for (int i = 0; i < data.getClipData().getItemCount(); i++) {
-        paths.add(fileUtils.getPathFromUri(activity, data.getClipData().getItemAt(i).getUri()));
+      
+      if (data.getClipData() != null) {
+        for (int i = 0; i < data.getClipData().getItemCount(); i++) {
+          paths.add(fileUtils.getPathFromUri(activity, data.getClipData().getItemAt(i).getUri()));
+        }
+      } else {
+        paths.add(fileUtils.getPathFromUri(activity, data.getData()));
       }
       handleMultiImageResult(paths, false);
       return;

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.7.5
+version: 0.7.4
 
 flutter:
   plugin:


### PR DESCRIPTION
While attempting to select only one image from gallery using getMultiImage()
`java.lang.NullPointerException: Attempt to invoke virtual method 'int android.content.ClipData.getItemCount()' on a null object reference`
